### PR TITLE
Fix: Correct alignment and Grogu animation issues

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -190,16 +190,26 @@ a:hover {
   cursor: pointer;
 }
 
+/* Added style for Grogu's click animation */
+#grogu.grogu-animating-click {
+  /* scale combines with translateY from float animation */
+  transform: scale(1.1); 
+  transition: transform 0.1s ease-out;
+}
+
 .fireball {
-  position: absolute;
+  /* position: fixed is set here to ensure viewport-relative positioning */
+  position: fixed; 
   width: 20px;
   height: 20px;
   background: radial-gradient(circle, #ff4500 20%, #ff8c00 50%, transparent 70%);
   border-radius: 50%;
   box-shadow: 0 0 15px 5px rgba(255, 69, 0, 0.7), 0 0 25px 10px rgba(255, 140, 0, 0.5);
   opacity: 0;
-  z-index: 0;
+  /* Ensure fireball is above Grogu (z-index: 10) and other elements if needed */
+  z-index: 11; 
   animation: shootFireball 2s ease-out forwards, pulseFireball 0.5s infinite alternate;
+  /* transform: translate(-50%, -50%) is set by JS to center the element on its left/top coords */
 }
 
 .fireball::after {
@@ -367,6 +377,33 @@ a:hover {
 
 /* Media Queries */
 @media (min-width: 769px) {
+  /* Make the main category container flex for horizontal layout */
+  .root > .children {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center; /* Center the category nodes */
+    padding-left: 0; /* Remove default padding, as it's for vertical list */
+  }
+
+  /* Adjust category nodes for flex layout */
+  .root > .children > .node {
+    width: auto; /* Let content and flex properties determine size */
+    max-width: 270px; /* Allow 2 nodes side-by-side within root's 600px max-width */
+    /* margin: 0.5rem; is already there and should work for spacing */
+  }
+
+  /* Hide the vertical connecting line for the root's children container,
+     as children are now horizontal. */
+  .root > .children::before {
+    display: none;
+  }
+
+  /* Hide the horizontal connecting line for category nodes if they are direct children of root's children,
+     as their parent is now a flex container and the line might not align well. */
+  .root > .children > .node > .node-content::before {
+    display: none;
+  }
+
   .mindmap { padding: 2rem; }
   .node-content { font-size: 1rem; }
   .root > .node-content { font-size: 1.2rem; }
@@ -540,6 +577,6 @@ body.dark-mode #dark-mode-toggle:hover {
 
 @media (max-width: 480px) {
   #dark-mode-toggle {
-    right: 100px; /* Further adjust for very small screens */
+    right: 115px; /* Further adjust for very small screens to prevent overlap with music toggle */
   }
 }

--- a/js/script.js
+++ b/js/script.js
@@ -88,31 +88,43 @@ spaceship.addEventListener('animationiteration', () => {
 function createFireball(isClick = false) {
   const fireball = document.createElement('div');
   fireball.classList.add('fireball');
-  grogu.appendChild(fireball);
+
+  // Get Grogu's current position to make fireball launch from there
+  const groguRect = grogu.getBoundingClientRect();
+  // Calculate center of Grogu as the spawn point for the fireball's center
+  const initialX = groguRect.left + (groguRect.width / 2);
+  const initialY = groguRect.top + (groguRect.height * 0.2); // Approx 20% from Grogu's top
+
+  // Note: .fireball CSS class should set position:fixed and appropriate z-index.
+  // JS sets initial coordinates and transform to center the fireball.
+  fireball.style.left = `${initialX}px`;
+  fireball.style.top = `${initialY}px`;
+  fireball.style.transform = 'translate(-50%, -50%)'; 
+
+  document.body.appendChild(fireball); // Append to body for stable positioning context
 
   const angle = (Math.random() - 0.5) * 30;
-  const xOffset = -100 + (Math.random() - 0.5) * 40;
+  // xOffset and yOffset define the travel distance and direction from its starting point
+  const xOffset = -100 + (Math.random() - 0.5) * 40; 
   const yOffset = -60 + (Math.random() - 0.5) * 20;
-
-  fireball.style.left = '50%';
-  fireball.style.top = '20%';
-  fireball.style.transform = 'translateX(-50%)';
 
   fireball.style.setProperty('--x-end', `${xOffset}px`);
   fireball.style.setProperty('--y-end', `${yOffset}px`);
   fireball.style.setProperty('--rotate-end', `${360 + angle}deg`);
 
   if (isClick) {
-    grogu.style.transition = 'transform 0.1s';
-    grogu.style.transform = 'scale(1.1)';
+    // Apply click animation using a class to avoid direct style manipulation conflicts
+    grogu.classList.add('grogu-animating-click');
     setTimeout(() => {
-      grogu.style.transform = 'translateY(0)';
-    }, 100);
+      grogu.classList.remove('grogu-animating-click');
+    }, 150); // Duration of click animation
   }
 
   fireball.addEventListener('animationend', (e) => {
-    if (e.animationName === 'shootFireball' && fireball.parentNode) {
-      grogu.removeChild(fireball);
+    // Ensure we only remove it after the main 'shootFireball' animation
+    // and check if it's still a child of document.body
+    if (e.animationName === 'shootFireball' && fireball.parentNode === document.body) {
+      document.body.removeChild(fireball);
     }
   });
 }


### PR DESCRIPTION
This commit addresses layout problems on desktop and mobile, and resolves issues with Grogu's animations.

Alignment:
- Desktop: Main category nodes in the mindmap now display horizontally for improved readability on wider screens.
- Mobile: Ensured toggle buttons (dark mode, music) do not overlap on smaller screens. Mindmap nodes remain stacked vertically for mobile usability.

Grogu Animations:
- Fireball Trajectory: Fireballs are now appended to the document body and use fixed positioning relative to the viewport. Their initial position is dynamically calculated based on Grogu's current location, ensuring a consistent trajectory regardless of Grogu's float animation.
- Click Animation: Grogu's click feedback (scaling effect) is now handled by adding/removing a CSS class, preventing conflicts with the primary float animation. This results in smoother animations.
- Z-index for fireballs has been adjusted to ensure they appear above Grogu.